### PR TITLE
Update chemical.py

### DIFF
--- a/MolNexTR/chemical.py
+++ b/MolNexTR/chemical.py
@@ -5,6 +5,7 @@ import numpy as np
 import multiprocessing
 import rdkit
 import rdkit.Chem as Chem
+from rdkit.Chem import rdFMCS, rdDepictor
 rdkit.RDLogger.DisableLog('rdApp.*')
 from SmilesPE.pretokenizer import atomwise_tokenizer
 from MolNexTR.abbrs import RGROUP_SYMBOLS, ABBREVIATIONS, VALENCES, FORMULA_REGEX,SUBSTITUTIONS


### PR DESCRIPTION
`rdFMCS` and `rdDepictor` are undefined in the `chemical.py` file. 
I added a simple import at the top to resolve them with the least amount of line changes.